### PR TITLE
Make 1.2.1 compatible with node v0.10.x; 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '0.10'
   - '0.11'
   - '0.12'
   - 'iojs-1'

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -26,7 +26,17 @@
 var net = require('net');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
-var debug = util.debuglog('http');
+var debug;
+var node10 = process.version.indexOf('v0.10.') === 0;
+if (node10) {
+    debug = function () {
+        if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
+            console.log.apply(console.log, arguments);
+        }
+    };
+} else {
+    debug = util.debuglog('http');
+}
 
 // New Agent code.
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -29,13 +29,13 @@ var EventEmitter = require('events').EventEmitter;
 var debug;
 var node10 = process.version.indexOf('v0.10.') === 0;
 if (node10) {
-    debug = function () {
-        if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
-            console.log.apply(console.log, arguments);
-        }
-    };
+  debug = function () {
+    if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
+      console.log.apply(console.log, arguments);
+    }
+  };
 } else {
-    debug = util.debuglog('http');
+  debug = util.debuglog('http');
 }
 
 // New Agent code.

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -19,9 +19,20 @@
 
 var util = require('util');
 var https = require('https');
-var debug = util.debuglog('http');
+var debug;
 var OriginalAgent = require('./_http_agent').Agent;
 var OriginalHttpsAgent = https.Agent;
+var node10 = process.version.indexOf('v0.10.') === 0;
+
+if (node10) {
+    debug = function () {
+        if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
+            console.log.apply(console.log, arguments);
+        }
+    };
+} else {
+    debug = util.debuglog('http');
+}
 
 module.exports = Agent;
 
@@ -72,6 +83,25 @@ Agent.prototype.createSocket = function (req, options) {
   return socket;
 };
 
+if (node10) {
+    Agent.prototype.removeSocket = function (s, options) {
+      OriginalAgent.prototype.removeSocket.call(this, s, options);
+      var name = this.getName(options);
+      debug('removeSocket', name, 'destroyed:', s.destroyed);
+
+      if (s.destroyed && this.freeSockets[name]) {
+        var index = this.freeSockets[name].indexOf(s);
+        if (index !== -1) {
+          this.freeSockets[name].splice(index, 1);
+          if (this.freeSockets[name].length === 0) {
+            // don't leak
+            delete this.freeSockets[name];
+          }
+        }
+      }
+    };
+}
+
 function HttpsAgent(options) {
   Agent.call(this, options);
   this.defaultPort = 443;
@@ -80,7 +110,41 @@ function HttpsAgent(options) {
 
 util.inherits(HttpsAgent, Agent);
 
+if (node10) {
+HttpsAgent.prototype.createConnection = https.globalAgent.createConnection;
+HttpsAgent.prototype.getName = function(options) {
+  var name = Agent.prototype.getName.call(this, options);
+
+  name += ':';
+  if (options.ca)
+    name += options.ca;
+
+  name += ':';
+  if (options.cert)
+    name += options.cert;
+
+  name += ':';
+  if (options.ciphers)
+    name += options.ciphers;
+
+  name += ':';
+  if (options.key)
+    name += options.key;
+
+  name += ':';
+  if (options.pfx)
+    name += options.pfx;
+
+  name += ':';
+  if (options.rejectUnauthorized !== undefined)
+    name += options.rejectUnauthorized;
+
+  return name;
+};
+
+} else {
 HttpsAgent.prototype.createConnection = OriginalHttpsAgent.prototype.createConnection;
 HttpsAgent.prototype.getName = OriginalHttpsAgent.prototype.getName;
+}
 
 Agent.HttpsAgent = HttpsAgent;

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -25,13 +25,13 @@ var OriginalHttpsAgent = https.Agent;
 var node10 = process.version.indexOf('v0.10.') === 0;
 
 if (node10) {
-    debug = function () {
-        if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
-            console.log.apply(console.log, arguments);
-        }
-    };
+  debug = function () {
+    if (process.env.NODE_DEBUG && /agentkeepalive/.test(process.env.NODE_DEBUG)) {
+      console.log.apply(console.log, arguments);
+    }
+  };
 } else {
-    debug = util.debuglog('http');
+  debug = util.debuglog('http');
 }
 
 module.exports = Agent;
@@ -83,25 +83,6 @@ Agent.prototype.createSocket = function (req, options) {
   return socket;
 };
 
-if (node10) {
-    Agent.prototype.removeSocket = function (s, options) {
-      OriginalAgent.prototype.removeSocket.call(this, s, options);
-      var name = this.getName(options);
-      debug('removeSocket', name, 'destroyed:', s.destroyed);
-
-      if (s.destroyed && this.freeSockets[name]) {
-        var index = this.freeSockets[name].indexOf(s);
-        if (index !== -1) {
-          this.freeSockets[name].splice(index, 1);
-          if (this.freeSockets[name].length === 0) {
-            // don't leak
-            delete this.freeSockets[name];
-          }
-        }
-      }
-    };
-}
-
 function HttpsAgent(options) {
   Agent.call(this, options);
   this.defaultPort = 443;
@@ -111,40 +92,40 @@ function HttpsAgent(options) {
 util.inherits(HttpsAgent, Agent);
 
 if (node10) {
-HttpsAgent.prototype.createConnection = https.globalAgent.createConnection;
-HttpsAgent.prototype.getName = function(options) {
-  var name = Agent.prototype.getName.call(this, options);
+  HttpsAgent.prototype.createConnection = https.globalAgent.createConnection;
+  HttpsAgent.prototype.getName = function(options) {
+    var name = Agent.prototype.getName.call(this, options);
 
-  name += ':';
-  if (options.ca)
-    name += options.ca;
+    name += ':';
+    if (options.ca)
+      name += options.ca;
 
-  name += ':';
-  if (options.cert)
-    name += options.cert;
+    name += ':';
+    if (options.cert)
+      name += options.cert;
 
-  name += ':';
-  if (options.ciphers)
-    name += options.ciphers;
+    name += ':';
+    if (options.ciphers)
+      name += options.ciphers;
 
-  name += ':';
-  if (options.key)
-    name += options.key;
+    name += ':';
+    if (options.key)
+      name += options.key;
 
-  name += ':';
-  if (options.pfx)
-    name += options.pfx;
+    name += ':';
+    if (options.pfx)
+      name += options.pfx;
 
-  name += ':';
-  if (options.rejectUnauthorized !== undefined)
-    name += options.rejectUnauthorized;
+    name += ':';
+    if (options.rejectUnauthorized !== undefined)
+      name += options.rejectUnauthorized;
 
-  return name;
+    return name;
 };
 
 } else {
-HttpsAgent.prototype.createConnection = OriginalHttpsAgent.prototype.createConnection;
-HttpsAgent.prototype.getName = OriginalHttpsAgent.prototype.getName;
+  HttpsAgent.prototype.createConnection = OriginalHttpsAgent.prototype.createConnection;
+  HttpsAgent.prototype.getName = OriginalHttpsAgent.prototype.getName;
 }
 
 Agent.HttpsAgent = HttpsAgent;

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "should": "~4.0.4",
     "should-http": "~0.0.2"
   },
-  "engines": { "node": ">= 0.11.12" },
+  "engines": { "node": ">= 0.10.0" },
   "author": "fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)",
   "license": "MIT"
 }

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -465,7 +465,7 @@ describe('agent.test.js', function () {
           agentkeepalive.sockets.should.not.have.key(name);
           agentkeepalive.freeSockets.should.not.have.key(name);
           done();
-        }, 510);
+        }, 550);
       });
     });
     agentkeepalive.sockets.should.have.key(name);

--- a/test/https_agent.test.js
+++ b/test/https_agent.test.js
@@ -27,8 +27,13 @@ describe('https_agent.test.js', function () {
     maxSockets: 5,
     maxFreeSockets: 5,
   });
+  var nodeTlsRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  var node10 = process.version.indexOf('v0.10.') === 0;
 
   before(function (done) {
+    if (node10) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+    }
     app = https.createServer({
       key: fs.readFileSync(__dirname + '/fixtures/agenttest-key.pem'),
       cert: fs.readFileSync(__dirname + '/fixtures/agenttest-cert.pem'),
@@ -61,6 +66,10 @@ describe('https_agent.test.js', function () {
   });
 
   after(function (done) {
+    if (node10) {
+      // recover original setting
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = nodeTlsRejectUnauthorized;
+    }
     setTimeout(done, 1500);
   });
 


### PR DESCRIPTION
#### Caveats
- two https tests are failing on windows (node v0.10.36 + Windows, probably related to #17 )
- had to increase timeout for one test from 510ms to 550ms
- tried to minimize all changes
- tried to 'merge' 0.2.x node v0.10.x specific code into 1.2.1 (master branch)

#### Tests
- all http tests and one https test ran with node v0.10.36 + Windows (had to set one environment variable `NODE_TLS_REJECT_UNAUTHORIZED="0"`
- all tests ran with node v0.11.16 + OS X

We need this library to work with node 0.10.x, 0.11.x, and 0.12.x in our project.

Sorry if i did not format the code correctly.
