### PR TITLE
Remove socket from freeSockets on 'timeout'

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -248,6 +248,17 @@ Agent.prototype.createSocket = function(req, options) {
 
   function onTimeout() {
     debug('CLIENT socket onTimeout');
+    // Remove it from freeSockets immediately to prevent new requests from being sent through this socket.
+    var sockets = self.freeSockets;
+    if (sockets[name]) {
+      var index = sockets[name].indexOf(s);
+      if (index !== -1) {
+        sockets[name].splice(index, 1);
+        // Don't leak
+        if (sockets[name].length === 0)
+          delete sockets[name];
+      }
+    }
     s.destroy();
     self.emit('timeout');
   }


### PR DESCRIPTION
Prevents a condition where a socket is used for a new request at the same time as being destroyed.
Addresses https://github.com/node-modules/agentkeepalive/issues/23