### PR TITLE
Add browser shim (noop) for isomorphic use.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,5 @@
+module.exports = noop;
+module.exports.HttpsAgent = noop;
+
+// Noop function for browser since native api's don't use agents.
+function noop () {}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "2.1.1",
   "description": "Missing keepalive http.Agent",
   "main": "index.js",
+  "browser": "browser.js",
   "files": [
     "index.js",
+    "browser.js",
     "lib"
   ],
   "scripts": {


### PR DESCRIPTION
This allows for the module to be consumed isomorphically. For example with "isomorphic-fetch" / "node-fetch".

The browser doesn't use http.Agent and this change just makes it so that bundlers like browserify/webpack/rollup will export this module as a noop.