### PR TITLE
New configuration for expiring sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $ npm install agentkeepalive --save
   * `maxFreeSockets` {Number} Maximum number of sockets to leave open
     in a free state. Only relevant if `keepAlive` is set to `true`.
     Default = `256`.
+  * `socketActiveTTL` {Number} Sets the socket active time to live, even if it's in use. 
+    If not setted the behaviour continues the same (the socket will be released only when free)
+    Default = `null`.
 
 ## Usage
 

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -62,6 +62,7 @@ function Agent(options) {
   self.keepAlive = self.options.keepAlive || false;
   self.maxSockets = self.options.maxSockets || Agent.defaultMaxSockets;
   self.maxFreeSockets = self.options.maxFreeSockets || 256;
+  self.socketActiveTTL = self.options.socketActiveTTL || null;
 
   // [patch start]
   // free keep-alive socket timeout. By default free socket do not have a timeout.
@@ -208,6 +209,21 @@ Agent.prototype.addRequest = function addRequest(req, options) {
     if (!this.freeSockets[name].length)
       delete this.freeSockets[name];
 
+    if (this.socketActiveTTL && new Date().getTime() - socket.createdTime > this.socketActiveTTL) {
+      debug(`socket ${socket.createdTime} expired`);
+      socket.destroy();
+      socket = this.createSocket(req, options, function(err, newSocket) {
+        if (err) {
+          process.nextTick(function() {
+            req.emit('error', err);
+          });
+          return;
+        }
+        req.onSocket(newSocket);
+      });
+      return;
+    }
+
     socket.ref();
     req.onSocket(socket);
     this.sockets[name].push(socket);
@@ -252,7 +268,7 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   debug('createConnection', name, options);
   options.encoding = null;
   var called = false;
-  const newSocket = self.createConnection(options, oncreate);
+  const newSocket = Object.assign(self.createConnection(options, oncreate), { createdTime: new Date().getTime() });
   if (newSocket)
     oncreate(null, newSocket);
   function oncreate(err, s) {

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -193,6 +193,18 @@ Agent.prototype.addRequest = function addRequest(req, options) {
   var freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
   var sockLen = freeLen + this.sockets[name].length;
 
+  function handleSocketCreation(req) {
+    return function(err, newSocket) {
+      if (err) {
+        process.nextTick(function() {
+          req.emit('error', err);
+        });
+        return;
+      }
+      req.onSocket(newSocket);
+    }
+  }
+
   if (freeLen) {
     // we have a free socket, so use that.
     var socket = this.freeSockets[name].shift();
@@ -212,15 +224,7 @@ Agent.prototype.addRequest = function addRequest(req, options) {
     if (this.socketActiveTTL && new Date().getTime() - socket.createdTime > this.socketActiveTTL) {
       debug(`socket ${socket.createdTime} expired`);
       socket.destroy();
-      socket = this.createSocket(req, options, function(err, newSocket) {
-        if (err) {
-          process.nextTick(function() {
-            req.emit('error', err);
-          });
-          return;
-        }
-        req.onSocket(newSocket);
-      });
+      socket = this.createSocket(req, options, handleSocketCreation(req));
       return;
     }
 
@@ -230,15 +234,7 @@ Agent.prototype.addRequest = function addRequest(req, options) {
   } else if (sockLen < this.maxSockets) {
     debug('call onSocket', sockLen, freeLen);
     // If we are under maxSockets create a new one.
-    this.createSocket(req, options, function(err, newSocket) {
-      if (err) {
-        process.nextTick(function() {
-          req.emit('error', err);
-        });
-        return;
-      }
-      req.onSocket(newSocket);
-    });
+    this.createSocket(req, options, handleSocketCreation(req));
   } else {
     debug('wait for socket');
     // We are over limit so we'll add it to the queue.

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -221,11 +221,10 @@ Agent.prototype.addRequest = function addRequest(req, options) {
     if (!this.freeSockets[name].length)
       delete this.freeSockets[name];
 
-    if (this.socketActiveTTL && new Date().getTime() - socket.createdTime > this.socketActiveTTL) {
+    if (this.socketActiveTTL && Date.now() - socket.createdTime > this.socketActiveTTL) {
       debug(`socket ${socket.createdTime} expired`);
       socket.destroy();
-      socket = this.createSocket(req, options, handleSocketCreation(req));
-      return;
+      return this.createSocket(req, options, handleSocketCreation(req));
     }
 
     socket.ref();
@@ -266,7 +265,7 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   var called = false;
   const newSocket = self.createConnection(options, oncreate);
   if (newSocket) {
-    oncreate(null, Object.assign(newSocket, { createdTime: new Date().getTime() }));
+    oncreate(null, Object.assign(newSocket, { createdTime: Date.now() }));
   }
   function oncreate(err, s) {
     if (called)

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -268,9 +268,10 @@ Agent.prototype.createSocket = function createSocket(req, options, cb) {
   debug('createConnection', name, options);
   options.encoding = null;
   var called = false;
-  const newSocket = Object.assign(self.createConnection(options, oncreate), { createdTime: new Date().getTime() });
-  if (newSocket)
-    oncreate(null, newSocket);
+  const newSocket = self.createConnection(options, oncreate);
+  if (newSocket) {
+    oncreate(null, Object.assign(newSocket, { createdTime: new Date().getTime() }));
+  }
   function oncreate(err, s) {
     if (called)
       return;


### PR DESCRIPTION
Long story short: we need to expire socket connection even it's in use.

My team made this changes because we were having trouble with DNS resolution. What?!? Yes, we use microservices architecture and when other systems (we depend) change DNS CNAME we have to restart the application to get new resolution and they cannot kill the unwanted stack til we make that move. We have about 4k rpm and several deploys during the day.

This lib is very very useful for us and we think this changes could be useful for others.