### PR TITLE
fix: sockLen was being miscalculated when removing sockets

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -380,7 +380,7 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
 
   // [patch start]
   var freeLen = this.freeSockets[name] ? this.freeSockets[name].length : 0;
-  var sockLen = freeLen + this.sockets[name] ? this.sockets[name].length : 0;
+  var sockLen = freeLen + (this.sockets[name] ? this.sockets[name].length : 0);
   // [patch end]
 
   if (this.requests[name] && this.requests[name].length && sockLen < this.maxSockets) {


### PR DESCRIPTION
Order of operations issue with + and ternary statements:

    console.log(0 + '' ? 'a' : 'b') // a

The code:

    freeLen + this.sockets[name] ? this.sockets[name].length : 0;

Is equivalent to:

    (freeLen + this.sockets[name]) ? this.sockets[name].length : 0;

When `this.sockets[name]` exists, it is an array, `(freeLen + this.sockets[name])` evaluates to a string, which evaluates to a string (true). When it does not, `(freeLen + this.sockets[name])` evaluates to `NaN` (false).

Either way, `freeLen` is ignored, which does not seem intended.