### PR TITLE
fix: add the lost npm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "browser": "browser.js",
   "files": [
     "index.js",
+    "index.d.ts",
     "browser.js",
     "lib"
   ],


### PR DESCRIPTION
In https://github.com/node-modules/agentkeepalive/pull/65, we lost the `index.d.ts` in npm files config.