### PR TITLE
Add support to ES6 modules for the default agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = require('./lib/agent');
+module.exports.default = require('./lib/agent');
 module.exports.HttpsAgent = require('./lib/https_agent');
 module.exports.constants = require('./lib/constants');


### PR DESCRIPTION
Because the exported HttpAgent is not exported under the default namespace the following code makes HttpAgent to be _undefined_
```javascript
import HttpAgent, {HttpsAgent, HttpOptions, HttpsOptions} from "agentkeepalive";
console.log(HttpAgent) // undefinded
```
