### PR TITLE
fix: explicitly set `| undefined` in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,11 +39,11 @@ declare namespace AgentKeepAlive {
   }
 
   interface CommonHttpOption {
-    keepAlive?: boolean;
-    freeSocketTimeout?: number;
-    freeSocketKeepAliveTimeout?: number;
-    timeout?: number;
-    socketActiveTTL?: number;
+    keepAlive?: boolean | undefined;
+    freeSocketTimeout?: number | undefined;
+    freeSocketKeepAliveTimeout?: number | undefined;
+    timeout?: number | undefined;
+    socketActiveTTL?: number | undefined;
   }
 
   export interface HttpOptions extends http.AgentOptions, CommonHttpOption { }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Since TypeScript 4.4, the option `exactOptionalPropertyTypes` let users enforce that
`x?: Type` is different from `x: Type | undefined`.

The current definition of `CommonHttpOption` is invalid with this option activated.

This fix should solve the problem in a retrocompatible way, by adding `| undefined` on all optional properties.
