### PR TITLE
readme: making `timeout`'s default clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ npm install agentkeepalive --save
     Only relevant if `keepAlive` is set to `true`.
   * `timeout`: {Number} Sets the working socket to timeout
     after `timeout` milliseconds of inactivity on the working socket.
-    Default is `freeSocketTimeout * 2`.
+    Default is `freeSocketTimeout * 2` so long as that value is greater to or equal to 30 seconds, otherwise the default is 30 seconds.
   * `maxSockets` {Number} Maximum number of sockets to allow per
     host. Default = `Infinity`.
   * `maxFreeSockets` {Number} Maximum number of sockets (per host) to leave open

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ npm install agentkeepalive --save
     Only relevant if `keepAlive` is set to `true`.
   * `timeout`: {Number} Sets the working socket to timeout
     after `timeout` milliseconds of inactivity on the working socket.
-    Default is `freeSocketTimeout * 2` so long as that value is greater to or equal to 30 seconds, otherwise the default is 30 seconds.
+    Default is `freeSocketTimeout * 2` so long as that value is greater than or equal to 30 seconds, otherwise the default is 30 seconds.
   * `maxSockets` {Number} Maximum number of sockets to allow per
     host. Default = `Infinity`.
   * `maxFreeSockets` {Number} Maximum number of sockets (per host) to leave open


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

(I didn't find the contributing guideline clear on commit messages; it had `fix(*) ---`, but nothing on what docs updates should look like, which aren't quite a fix.)

##### Affected core subsystem(s)
None.


##### Description of change
README updated to make clear that `timeout`'s default will be greater to or equal to 30s.
