### PR TITLE
fix: change `freeSocketTimeout` default value to 4000

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,27 +5,42 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - main
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - main
+      - master
+  schedule:
+    - cron: '0 2 * * *'
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x]
+        node-version: [8, 10, 12, 14, 16]
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Git Source
+      uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npminstall && npminstall
-    - run: npm run ci
-      env:
-        CI: true
+
+    - name: Install Dependencies
+      run: npm i -g npminstall && npminstall
+
+    - name: Continuous Integration
+      run: npm run ci
+
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ $ npm install agentkeepalive --save
     Default = `1000`.  Only relevant if `keepAlive` is set to `true`.
   * `freeSocketTimeout`: {Number} Sets the free socket to timeout
     after `freeSocketTimeout` milliseconds of inactivity on the free socket.
-    Default is `15000`.
+    The default [server-side timeout](https://nodejs.org/api/http.html#serverkeepalivetimeout) is 5000 milliseconds, to [avoid ECONNRESET exceptions](https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83), we set the default value to `4000` milliseconds.
     Only relevant if `keepAlive` is set to `true`.
   * `timeout`: {Number} Sets the working socket to timeout
     after `timeout` milliseconds of inactivity on the working socket.
-    Default is `freeSocketTimeout * 2` so long as that value is greater than or equal to 30 seconds, otherwise the default is 30 seconds.
+    Default is `freeSocketTimeout * 2` so long as that value is greater than or equal to 8 seconds, otherwise the default is 8 seconds.
   * `maxSockets` {Number} Maximum number of sockets to allow per
     host. Default = `Infinity`.
   * `maxFreeSockets` {Number} Maximum number of sockets (per host) to leave open

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -31,9 +31,10 @@ class Agent extends OriginalAgent {
   constructor(options) {
     options = options || {};
     options.keepAlive = options.keepAlive !== false;
-    // default is keep-alive and 15s free socket timeout
+    // default is keep-alive and 4s free socket timeout
+    // see https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83
     if (options.freeSocketTimeout === undefined) {
-      options.freeSocketTimeout = 15000;
+      options.freeSocketTimeout = 4000;
     }
     // Legacy API: keepAliveTimeout should be rename to `freeSocketTimeout`
     if (options.keepAliveTimeout) {
@@ -51,8 +52,8 @@ class Agent extends OriginalAgent {
     // Sets the socket to timeout after timeout milliseconds of inactivity on the socket.
     // By default is double free socket timeout.
     if (options.timeout === undefined) {
-      // make sure socket default inactivity timeout >= 30s
-      options.timeout = Math.max(options.freeSocketTimeout * 2, 30000);
+      // make sure socket default inactivity timeout >= 8s
+      options.timeout = Math.max(options.freeSocketTimeout * 2, 8000);
     }
 
     // support humanize format

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "os": {
       "github": "linux"
     },
-    "version": "8, 10, 12, 14"
+    "version": "8, 10, 12, 14, 16"
   },
   "author": "fengmk2 <fengmk2@gmail.com> (https://fengmk2.com)",
   "license": "MIT"

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -70,8 +70,8 @@ describe('test/agent.test.js', () => {
     assert(agent.keepAliveMsecs === 1000);
     assert(agent.maxSockets === 5);
     assert(agent.maxFreeSockets === 5);
-    assert(agent.timeout === 30000);
-    assert(agent.options.timeout === 30000);
+    assert(agent.timeout === 8000);
+    assert(agent.options.timeout === 8000);
     assert(agent.freeSocketKeepAliveTimeout === 1000);
     assert(agent.options.freeSocketTimeout === 1000);
     assert(!agent.socketActiveTTL);
@@ -1648,7 +1648,7 @@ describe('test/agent.test.js', () => {
       const agent = new Agent();
 
       const options = {
-        host: 'registry.npmjs.org',
+        host: 'r.cnpmjs.org',
         port: 80,
         path: '/',
         agent,

--- a/test/https_agent.test.js
+++ b/test/https_agent.test.js
@@ -63,6 +63,7 @@ describe('test/https_agent.test.js', () => {
       port,
       path: '/',
       ca: fs.readFileSync(__dirname + '/fixtures/ca.pem'),
+      rejectUnauthorized: false,
     }, res => {
       assert(res.statusCode === 200);
       res.resume();
@@ -87,6 +88,7 @@ describe('test/https_agent.test.js', () => {
       path: '/?timeout=100',
       ca: fs.readFileSync(__dirname + '/fixtures/ca.pem'),
       timeout: 50,
+      rejectUnauthorized: false,
     }, res => {
       console.log(res.statusCode, res.headers);
       res.resume();
@@ -114,6 +116,7 @@ describe('test/https_agent.test.js', () => {
       timeout: 50,
       maxSockets: 5,
       maxFreeSockets: 5,
+      rejectUnauthorized: false,
     });
     https.get({
       agent,
@@ -139,6 +142,7 @@ describe('test/https_agent.test.js', () => {
       timeout: 0,
       maxSockets: 5,
       maxFreeSockets: 5,
+      rejectUnauthorized: false,
     });
     https.get({
       agent,
@@ -157,6 +161,7 @@ describe('test/https_agent.test.js', () => {
       port,
       path: '/',
       ca: fs.readFileSync(__dirname + '/fixtures/ca.pem'),
+      rejectUnauthorized: false,
     }, res => {
       assert(res.statusCode === 200);
       res.resume();
@@ -230,6 +235,7 @@ describe('test/https_agent.test.js', () => {
         port,
         path: '/?timeout=20000',
         timeout: 2500,
+        rejectUnauthorized: false,
         ca: fs.readFileSync(__dirname + '/fixtures/ca.pem'),
       }, res => {
         console.error(res.statusCode, res.headers);

--- a/test/test-ECONNRESET.test.js
+++ b/test/test-ECONNRESET.test.js
@@ -26,7 +26,7 @@ describe('test/test-ECONNRESET.test.js', () => {
     clearInterval(timer);
   });
 
-  it('should handle Keep-Alive header and not throw reset error', done => {
+  it('should resolved socket hang up and ECONNRESET errors', done => {
     const keepaliveAgent = new Agent({
       keepAlive: true,
       freeSocketTimeout: 900,

--- a/test/test-ECONNRESET.test.js
+++ b/test/test-ECONNRESET.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('assert');
+const http = require('http');
+const Agent = require('..');
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83
+describe('test/test-ECONNRESET.test.js', () => {
+  let port;
+  let server;
+  let timer;
+  before(done => {
+    server = http.createServer((req, res) => {
+      res.end('Hello World');
+    });
+    server.keepAliveTimeout = 1000;
+    server.listen(0, err => {
+      port = server.address().port;
+      done(err);
+    });
+  });
+
+  after(() => {
+    clearInterval(timer);
+  });
+
+  it('should handle Keep-Alive header and not throw reset error', done => {
+    const keepaliveAgent = new Agent({
+      keepAlive: true,
+      freeSocketTimeout: 900,
+    });
+
+    function request() {
+      return new Promise((resolve, reject) => {
+        const req = http.request({
+          method: 'GET',
+          port,
+          path: '/',
+          agent: keepaliveAgent,
+        }, res => {
+          const chunks = [];
+          res.on('data', data => {
+            chunks.push(data);
+          });
+          res.on('end', () => {
+            const text = Buffer.concat(chunks).toString();
+            resolve(text);
+          });
+        });
+        req.on('error', err => {
+          reject(err);
+        });
+        req.end();
+      });
+    }
+
+    async function startSendingRequests() {
+      let successes = 0;
+      const failures = {};
+
+      for (let i = 0; i < 10; i++) {
+        await wait(999);
+        try {
+          await request();
+          successes++;
+        } catch (e) {
+          failures[e.message] = (failures[e.message] || 0) + 1;
+        }
+      }
+      return { successes, failures };
+    }
+
+    startSendingRequests().then(({ successes, failures }) => {
+      assert(Object.keys(failures).length === 0);
+      assert(successes === 10);
+      done();
+    });
+  });
+});

--- a/test/test-https-ipv6.test.js
+++ b/test/test-https-ipv6.test.js
@@ -58,6 +58,7 @@ describe('test/test-ipv6.test.js', () => {
       port,
       path: '/',
       ca: fs.readFileSync(__dirname + '/fixtures/ca.pem'),
+      rejectUnauthorized: false,
     }, res => {
       assert(res.statusCode === 200);
       res.resume();


### PR DESCRIPTION
The default server-side timeout is 5000 milliseconds, to avoid
ECONNRESET exceptions, we set the default value to `4000` milliseconds.

See 'race condition' detail on https://github.com/node-modules/agentkeepalive/issues/57

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
