### PR TITLE
feat: Return socket from createConnection and add type for createConnection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
+import * as net from 'net';
 
 interface PlainObject {
   [key: string]: any;
@@ -8,6 +9,7 @@ interface PlainObject {
 declare class HttpAgent extends http.Agent {
   constructor(opts?: AgentKeepAlive.HttpOptions);
   readonly statusChanged: boolean;
+  createConnection(options: net.NetConnectOpts, cb?: Function): net.Socket;
   createSocket(req: http.IncomingMessage, options: http.RequestOptions, cb: Function): void;
   getCurrentStatus(): AgentKeepAlive.AgentStatus;
 }
@@ -52,6 +54,7 @@ declare namespace AgentKeepAlive {
   export class HttpsAgent extends https.Agent {
     constructor(opts?: HttpsOptions);
     readonly statusChanged: boolean;
+    createConnection(options: net.NetConnectOpts, cb?: Function): net.Socket;
     createSocket(req: http.IncomingMessage, options: http.RequestOptions, cb: Function): void;
     getCurrentStatus(): AgentStatus;
   }

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -230,6 +230,7 @@ class Agent extends OriginalAgent {
 
     const newSocket = super.createConnection(options, onNewCreate);
     if (newSocket) onNewCreate(null, newSocket);
+    return newSocket;
   }
 
   get statusChanged() {

--- a/lib/https_agent.js
+++ b/lib/https_agent.js
@@ -25,8 +25,8 @@ class HttpsAgent extends HttpAgent {
     };
   }
 
-  createConnection(options) {
-    const socket = this[CREATE_HTTPS_CONNECTION](options);
+  createConnection(options, oncreate) {
+    const socket = this[CREATE_HTTPS_CONNECTION](options, oncreate);
     this[INIT_SOCKET](socket, options);
     return socket;
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->
As per http.agent [createConnection](https://nodejs.org/api/http.html#agentcreateconnectionoptions-callback) method, the method should return a socket but I found that current implemenation of createConnection for Agent doesn't return socket.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
N/A

##### Description of change
<!-- Provide a description of the change below this comment. -->
Return socket from createConnection and add type for createConnection